### PR TITLE
C678 s3 access

### DIFF
--- a/name.tf
+++ b/name.tf
@@ -1,0 +1,11 @@
+resource "random_string" "resource_suffix" {
+  length  = 5
+  lower   = true
+  upper   = false
+  number  = false
+  special = false
+}
+
+locals {
+  resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -8,13 +8,13 @@ terraform {
 
 data "ns_workspace" "this" {}
 
-data "ns_connection" "s3" {
-  name = "s3"
-  type = "s3/aws"
+data "ns_connection" "s3_bucket" {
+  name = "s3_bucket"
+  type = "aws-s3"
 }
 
 locals {
-  s3_region      = data.ns_connection.s3.outputs.region
-  s3_bucket_arn  = data.ns_connection.s3.outputs.bucket_arn
-  s3_bucket_name = data.ns_connection.s3.outputs.bucket_name
+  s3_region      = data.ns_connection.s3_bucket.outputs.region
+  s3_bucket_arn  = data.ns_connection.s3_bucket.outputs.bucket_arn
+  s3_bucket_name = data.ns_connection.s3_bucket.outputs.bucket_name
 }

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -10,7 +10,7 @@ data "ns_workspace" "this" {}
 
 data "ns_connection" "s3_bucket" {
   name = "s3_bucket"
-  type = "aws-s3-bucket"
+  type = "bucket/aws-s3"
 }
 
 locals {

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -10,7 +10,7 @@ data "ns_workspace" "this" {}
 
 data "ns_connection" "s3_bucket" {
   name = "s3_bucket"
-  type = "aws-s3"
+  type = "aws-s3-bucket"
 }
 
 locals {

--- a/policy.tf
+++ b/policy.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role_policy" "access_" {
-  role   = var.app_metadata.task_role_name
+  role   = var.app_metadata.role_name
   policy = data.aws_iam_policy_document.access.json
 }
 

--- a/policy.tf
+++ b/policy.tf
@@ -1,0 +1,17 @@
+resource "aws_iam_role_policy" "access_" {
+  role   = var.app_metadata.task_role_name
+  policy = data.aws_iam_policy_document.access.json
+}
+
+data "aws_iam_policy_document" "access" {
+  statement {
+    sid     = "AllowFullAccess"
+    effect  = "Allow"
+    actions = ["s3:*"]
+
+    principals {
+      identifiers = [local.s3_bucket_arn, "${local.s3_bucket_arn}/*"]
+      type        = "AWS"
+    }
+  }
+}

--- a/policy.tf
+++ b/policy.tf
@@ -1,17 +1,19 @@
-resource "aws_iam_role_policy" "access_" {
-  role   = var.app_metadata.role_name
-  policy = data.aws_iam_policy_document.access.json
+resource "aws_iam_policy" "this" {
+  name = local.resource_name
+  policy = data.aws_iam_policy_document.this.json
 }
 
-data "aws_iam_policy_document" "access" {
+resource "aws_iam_role_policy_attachment" "this" {
+  role = var.app_metadata["role_name"]
+  policy_arn = aws_iam_policy.this.arn
+}
+
+data "aws_iam_policy_document" "this" {
   statement {
     sid     = "AllowFullAccess"
     effect  = "Allow"
     actions = ["s3:*"]
 
-    principals {
-      identifiers = [local.s3_bucket_arn, "${local.s3_bucket_arn}/*"]
-      type        = "AWS"
-    }
+    resources = [local.s3_bucket_arn, "${local.s3_bucket_arn}/*"]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,10 @@
+variable "app_metadata" {
+  description = <<EOF
+Nullstone automatically injects metadata from the app module into this module through this variable.
+This variable is a reserved variable for capabilities.
+This contains information like `security_group_id` that is used by the capability.
+EOF
+
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
This module takes in a `role_name` from aws-fargate-service via `app_metadata`. This capability has a single connection to the s3 bucket block. This module then creates a policy document to grant the necessary access to the s3 bucket. This policy is then attached to the role via a aws_iam_role_policy.